### PR TITLE
allow python versions above 3.8 in the ledger service run script

### DIFF
--- a/docker/run-dev.sh
+++ b/docker/run-dev.sh
@@ -4,9 +4,25 @@
 
 set -e
 
-if ! command -v python3.8 &> /dev/null; then
-    echo "python3.8 could not be found."
-    echo "On Ubuntu, run: apt install python3.8 python3.8-venv"
+# Check if Python3.x is installed
+if ! command -v python3 &> /dev/null; then
+    echo "Python is not installed"
+    exit 1
+fi
+
+# Get the Python version, pyscitt requires version 3.8 or more
+PYTHON_VERSION=$(python3 -c 'import sys; version=sys.version_info; print(f"{version[1]}")')
+
+MINIMUM_VERSION=3.8
+
+MINIMUM_VERSION=$(echo $MINIMUM_VERSION | cut -d. -f2)
+
+# Compare the Python version
+if awk 'BEGIN { if (('$PYTHON_VERSION' < '$MINIMUM_VERSION')) exit 0; exit 1 }'; then
+    echo "Installed version python3.$PYTHON_VERSION should be greater than python3.$MINIMUM_VERSION"
+    echo "On Ubuntu, run: apt install python3.$MINIMUM_VERSION python3.$MINIMUM_VERSION-venv"
+    exit 1
+fi
 
 PLATFORM=${PLATFORM:-sgx}
 CCF_HOST=${CCF_HOST:-"localhost"}
@@ -92,7 +108,7 @@ docker run --name "$CONTAINER_NAME" \
 
 echo "Setting up python virtual environment."
 if [ ! -f "venv/bin/activate" ]; then
-    python3.8 -m venv "venv"
+    python3 -m venv "venv"
 fi
 source venv/bin/activate 
 pip install --disable-pip-version-check -q -e ./pyscitt


### PR DESCRIPTION
Most of linux installations run python versions higher than 3.8. run-dev.sh is forcing to use python3.8, relaxed the restriction to allow python versions greater than 3.8 as required pyscitt setup file